### PR TITLE
Cache dependencies in CI

### DIFF
--- a/.github/workflows/build-and-e2e-test.yml
+++ b/.github/workflows/build-and-e2e-test.yml
@@ -35,15 +35,17 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Install Node.js, NPM and Yarn
+      - name: Install Node.js and Yarn
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile --network-timeout 560000
+
       - name: Increase watches
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
         if: matrix.os == 'ubuntu-latest'
 
-      - run: yarn install --network-timeout 560000
       - name: Run end2end tests
         run: ${{ matrix.E2E }}
       - run: yarn ${{ matrix.SHIP }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -29,15 +29,17 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Install Node.js, NPM and Yarn
+      - name: Install Node.js and Yarn
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile --network-timeout 560000
+
       - name: Increase watches
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
         if: matrix.os == 'ubuntu-latest'
 
-      - run: yarn install --network-timeout 560000
       - run: yarn lint-check
       - run: yarn compile-all
       - run: yarn test:unit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,13 @@ jobs:
       - name: Check out git repository
         uses: actions/checkout@v3
 
-      - name: Install Node.js, NPM and Yarn
+      - name: Install Node.js and Yarn
         uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: yarn install --network-timeout 560000
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile --network-timeout 560000
+
       - run: yarn ${{ matrix.SHIP }}
       - name: Upload release asset
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Yarn dependencies are cached in the CI in order to avoid unnecessary work.
